### PR TITLE
Set an absolute output path for webpack

### DIFF
--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   ],
   devtool: 'source-map',
   output: {
-    path: './priv/static',
+    path: __dirname + '/priv/static',
     filename: 'js/app.js'
   },
   module: {
@@ -51,4 +51,3 @@ module.exports = {
     extensions: ['.js', '.jsx']
   }
 };
-


### PR DESCRIPTION
When I tried to run the server webpack threw an error:

```
Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration.output.path: The provided value "./priv/static" is not an absolute path!
```

After doing all sorts of google-ing [this](http://stackoverflow.com/questions/42166492/getting-error-output-path-needs-to-be-an-absolute-path-or) seemed to fix the issue.